### PR TITLE
Support league/omnipay ~2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "illuminate/support": "^5",
-        "league/omnipay": "~3.0"
+        "league/omnipay": "~2.0|~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## What this did
Allow `league/omnipay` `~2.0` to be used.