### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Pre Laravel 5.5: After updating composer, add the ServiceProvider to the provide
 You need to publish the config for this package. A sample configuration is provided. The defaults will be merged with gateway specific configuration.
 
 ```
+
 $ php artisan vendor:publish --provider=Barryvdh\Omnipay\ServiceProvider
 ```
 


### PR DESCRIPTION
Added double quotes -> "Barryvdh\Omnipay\ServiceProvider". Without artisan complains: 'Unable to locate publishable resources.' 

More people were reporting this issue.